### PR TITLE
Add AleoGuard to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The following is a curated list of applications powered by Aleo.
 - [zkDrop](https://github.com/4sm-ops/zkDrop/) - Digital ID and secure file sharing concept based on Aleo
 - [ANS](https://github.com/S-T-Soft/aleo-name-service-contract) - The Aleo Naming Service
 - [zkKYC](https://github.com/B1boid/zk-KYC) - A privacy preserving Know Your Customer (KYC) application built on Aleo.
+- [AleoGuard](https://github.com/gitshreevatsa/AleoGuard) - A Privacy driven Identity aggregator for plug-and-play SSO built on Aleo
 
 ### Gaming
 


### PR DESCRIPTION
AleoGuard is a Privacy driven Identity aggregator for plug-and-play SSO This SSO is designed to move from custodial SSO like google GitHub connect to a more decentralized approach to improve the current web3 SSOs.

AleoGuard uses Aleo’s native high speed Zkproofs and privacy first policy to enable users to aggregate all their identities and have full discretion on how their private data is handled.