### PR TITLE
Fix incorrect project name + description

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ The following is a curated list of applications powered by Aleo.
 
 - [Where's Alex](https://github.com/puzzlehq/wheres_alex) - A multiparty hidden information game on Aleo
 - [Treasure Hunt](https://treasures.puzzle.online/) - A multiparty hidden treasure hunt game on Aleo
-- [Super Leo Ligue](https://aleo-fortune.vercel.app/) - Play classic casino games like roulette and more on Aleo
-- [Aleo Fortune](https://superleolig.vercel.app/) - Challenge a friend to an onchain soccer game with hidden strategies
+- [Super Leo Lig](https://superleolig.online/) - - Challenge a friend to an on-chain soccer game with hidden strategies
+- [Aleo Fortune](https://aleo-fortune.vercel.app/) - Play classic casino games like roulette and more on Aleo
 - [Puzzle SDK for zkGames](https://docs.puzzle.online/tutorials/build_your_first_zkgame/) - A SDK for building multiparty hidden information games on Aleo
 - [Zenet](https://github.com/ZenetGame/ZenetAleo) - The ancient Egyptian game of Senet on Aleo
 - [Battleship](https://github.com/demox-labs/zk-battleship) - ZK Battleship on Aleo


### PR DESCRIPTION
The description and link for Super Leo Lig and Aleo Fortune were mixed up. Also updated the Super Leo Lig link.